### PR TITLE
Add CTID

### DIFF
--- a/context-v1.json
+++ b/context-v1.json
@@ -11,6 +11,7 @@
     "alignments": {"@id": "ctdlasn:majorAlignment", "@type": "@id"},
     "author": {"@id": "ctdlasn:author"},
     "category": {"@id": "ctdlasn:competencyCategory"},
+    "ctid": {"@id": "ctdl:ctid"},
     "certifications": {"@id": "ctdlasn:alignFrom", "@type": "@id"},
     "containsSkill": {"@id": "ctdlasn:hasTopChild"},
     "employers": {"@id": "ctdl:employmentOutcome"},

--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
                     <td>alignments</td>
                     <td>Alignments</td>
                     <td>Array[String:URI]</td>
-                    <td>indicates alignment or overlap of this RSD to an underlying unique identifiers of standards,
+                    <td>indicates alignment or overlap of this RSD to underlying standards items,
                       skills, or competencies identified in other frameworks or data sources (i.e.,Emsi; Burning Glass;
                       LinkedIn; Workday)</td>
                     <td><a href="https://purl.org/ctdlasn/terms/majorAlignment">ctdlasn:majorAlignment</a>
@@ -211,6 +211,17 @@
                     <td>Array[String]</td>
                     <td>indicates alignment of this skill to data sources for professional standards or keywords that do not have canonical URIs</td>
                     <td><a href="https://purl.org/ctdlasn/terms/skillEmbodied">ctdlasn:skillEmbodied</a></td>
+                </tr>
+                <tr>
+                    <td>ctid</td>
+                    <td>Credential Transparency Identifier</td>
+                    <td>Array[String]</td>
+                    <td>
+                      Unique Credential Transparency Identifier assigned by the creator perhaps through publication to
+                      the Credential Engine Registry. Uniqueness can only be guaranteed for entities submitted to the
+                      Credential Engine Registry.
+                    </td>
+                    <td><a href="https://purl.org/ctdlasn/terms/ctid">ctdlasn:ctid</a></td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
In order to publish RSDs to the Credential Engine Registry, RSDs need to have ctids assigned. This adds a property for that to the context so that implementers can be advised how to use it when they wish to publish RSDs specifically to the Credential Engine Registry.